### PR TITLE
Fix error handling of some cases.

### DIFF
--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -904,8 +904,12 @@ _M.ssl = function(self)
         return
     end
 
+    local pem, err = file.load(self.conf.root..ssl_hostname..'.crt')
 
-    local pem = file.load(self.conf.root..ssl_hostname..'.crt')
+    if err then
+      log('Error reading cert: %s', err)
+      return
+    end
 
     local der_chain
     -- TODO: cache the pem_to_der conversion

--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -82,7 +82,7 @@ local http_request = function(uri, post_body, options)
     local res, err = httpc:request_uri(uri, defoptions)
 
     if not res then
-        return nil, 500, res.headers, "failed to request: " .. tostring(err)
+        return nil, 500, nil, "failed to request: " .. tostring(err)
     end
 
     --log('HTTP requested finished: %s bytes, status: %s', #res.body, res.status)

--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -904,14 +904,6 @@ _M.ssl = function(self)
         return
     end
 
-    -- clear the fallback certificates and private keys
-    -- set by the ssl_certificate and ssl_certificate_key
-    -- directives
-    ok, _ = ssl.clear_certs()
-    if not ok then
-        log"failed to clear existing (fallback) certificates"
-        return ngx.exit(ngx.ERROR)
-    end
 
     local pem = file.load(self.conf.root..ssl_hostname..'.crt')
 
@@ -923,11 +915,23 @@ _M.ssl = function(self)
     der_chain, err = ssl.cert_pem_to_der(pem)
     if not der_chain then
         log('Error %s, while converting pem chain to der', err)
+        return
     end
 
 
     -- Staple !
     self:ocsp_staple(ssl_hostname, der_chain)
+
+
+    -- clear the fallback certificates and private keys
+    -- set by the ssl_certificate and ssl_certificate_key
+    -- directives
+    ok, _ = ssl.clear_certs()
+    if not ok then
+        log"failed to clear existing (fallback) certificates"
+        return ngx.exit(ngx.ERROR)
+    end
+
 
     ok, err = ssl.set_der_cert(der_chain)
     if not ok then

--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -109,21 +109,19 @@ end
 local b64url = require'b64url'.encode
 package.preload['acme.error'] = function()
     return {
-        parse = function()
+        parse = function(err)
             local err_mt = {}
 
             function err_mt:__tostring()
                 return ("%d{%s}%s"):format(self.status or -1, self.type, self.detail or "")
             end
 
-            local function parse_error(err)
-                local jerr = json.decode(err)
-                if jerr then
-                    return setmetatable(jerr, err_mt)
-                end
-                return err
+            local jerr = json.decode(err)
+            if jerr then
+                setmetatable(jerr, err_mt)
+                return jerr
             end
-          return parse_error
+            return err
         end
     }
 end
@@ -591,7 +589,7 @@ _M.init_account = function(self)
         local reg, err = account.step({resource='new-reg', contact={self.conf.contact}, agreement=self.conf.agreement})
         --local reg, err = account.step({resource = 'new-reg', agreement = agreement})
         if not reg then
-            log('Error registering with ACME server: %s',tostring(err()))
+            log('Error registering with ACME server: %s',tostring(err))
         else
             log('Registration OK!')
             self.account_data.reg = reg


### PR DESCRIPTION
Before this we got `err: function: 0x41289ab0` printed as the error (with some custom logging) and this caused all sort of weird behaviour instead.

I managed to get the local key in a state where it didn't register right, but it thought it did, so it had accounts.json/.key. (I'm working on more fixes. Thanks for this project though!)

Before the change:

```
2016/04/04 20:25:18 [error] 77#77: [lua] letsencrypt.lua:62: log(): ___***___: Updating authz..., context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 20:25:18 [error] 77#77: [lua] letsencrypt.lua:62: log(): ___***___: HTTP request: https://acme-staging.api.letsencrypt.org/acme/new-authz, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 20:25:18 [error] 77#77: [lua] letsencrypt.lua:62: log(): ___***___: Failed to update authz: function: 0x40fb7d60, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 20:25:18 [error] 77#77: lua entry thread aborted: runtime error: /etc/nginx/lualib/ngx/ssl.lua:154: attempt to get length of local 'pem' (a nil value)
stack traceback:
coroutine 0:
        /etc/nginx/lualib/ngx/ssl.lua: in function 'cert_pem_to_der'
        /etc/nginx/lualib/letsencrypt.lua:925: in function 'ssl'
        ssl_certificate_by_lua:2: in function <ssl_certificate_by_lua:1>, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
```

With this change I now end up with this in the log:

```
2016/04/04 21:06:45 [error] 107#107: [lua] letsencrypt.lua:91: log(): ___***___: cert_for_host(d81b3b58.ngrok.io), context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 21:06:45 [error] 107#107: [lua] letsencrypt.lua:91: log(): ___***___: Updating authz..., context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 21:06:45 [error] 107#107: [lua] letsencrypt.lua:91: log(): ___***___: HTTP request: https://acme-staging.api.letsencrypt.org/acme/new-authz, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 21:06:45 [error] 107#107: [lua] letsencrypt.lua:91: log(): ___***___: Failed to update authz: 405{urn:acme:error:malformed}Method not allowed, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
2016/04/04 21:06:45 [error] 107#107: [lua] letsencrypt.lua:91: log(): ___***___: Error reading cert: /etc/nginx/letsencrypt/d81b3b58.ngrok.io.crt: No such file or directory, context: ssl_certificate_by_lua*, client: 192.168.64.1, server: 0.0.0.0:443
```

I haven't yet fixed the error case of either why the reg is failing, or what new-authz wants (I guess we're doing a GET when it should be a POST?)
