### PR TITLE
Fix acme error parsing module bundle

### DIFF
--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -108,23 +108,21 @@ package.preload['b64url'] = function()
 end
 local b64url = require'b64url'.encode
 package.preload['acme.error'] = function()
-    return {
-        parse = function()
-            local err_mt = {}
+    local err_mt = {}
+    function err_mt:__tostring()
+        return ("%d{%s}%s"):format(self.status or -1, self.type, self.detail or "");
+    end
 
-            function err_mt:__tostring()
-                return ("%d{%s}%s"):format(self.status or -1, self.type, self.detail or "")
-            end
-
-            local function parse_error(err)
-                local jerr = json.decode(err)
-                if jerr then
-                    return setmetatable(jerr, err_mt)
-                end
-                return err
-            end
-          return parse_error
+    local function parse_error(err)
+        local jerr = json.decode(err);
+        if jerr then
+            return setmetatable(jerr, err_mt);
         end
+        return err;
+    end
+
+    return {
+        parse = parse_error;
     }
 end
 local parse_error = require'acme.error'.parse
@@ -591,7 +589,7 @@ _M.init_account = function(self)
         local reg, err = account.step({resource='new-reg', contact={self.conf.contact}, agreement=self.conf.agreement})
         --local reg, err = account.step({resource = 'new-reg', agreement = agreement})
         if not reg then
-            log('Error registering with ACME server: %s',tostring(err()))
+            error('Error registering with ACME server: ' .. tostring(err))
         else
             log('Registration OK!')
             self.account_data.reg = reg


### PR DESCRIPTION
We'd incorrectly imported the acme.error module so that the result
wasn't the same. Source
https://code.zash.se/lua-acme/file/3ff397e97d55/error.lua

And abort of we can't register -- there is no point continuing and
trying to validate a domain if the auth failed as the next operation
would just return with a 403 anyway.
