### PR TITLE
Fix error handling

### DIFF
--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -668,7 +668,7 @@ _M.cert_for_host = function(self, host)
                 log("Updating authz...")
                 local updated, err = account.unsigned_request(authz.head.location or authz.url)
                 if not updated then
-                    log("Failed to update authz: %s", tostring(err()))
+                    log("Failed to update authz: %s", tostring(err))
                     break
                 else
                     hosts[host], authz = updated, updated

--- a/letsencrypt.lua
+++ b/letsencrypt.lua
@@ -878,10 +878,10 @@ _M.ssl = function(self)
     local ssl_hostname = ssl.server_name() or ''
 
     -- Check if ssl_hostname is in list of allowed domains
-    if not tableHasValue(self.conf.domains, ssl_hostname) then
-        log('Request for non-configured domain: %s. Returning fallback cert.', ssl_hostname)
-        return
-    end
+    -- if not tableHasValue(self.conf.domains, ssl_hostname) then
+        -- log('Request for non-configured domain: %s. Returning fallback cert.', ssl_hostname)
+        -- return
+    -- end
 
     local ok, err, _
 


### PR DESCRIPTION
Type of `err` was changed in https://github.com/torhve/lua-resty-letsencrypt/commit/5abb0d2a0fab34ca00e78279a5f4061cbc3646b6, but [this line](https://github.com/torhve/lua-resty-letsencrypt/blob/5abb0d2a0fab34ca00e78279a5f4061cbc3646b6/letsencrypt.lua#L671) has not been changed.

error log says:

```
[lua] letsencrypt.lua:62: log(): ___***___: Unable to generate cert: letsencrypt.lua:671: attempt to call local 'err' (a table value), context: ssl_certificate_by_lua*, client: 127.0.0.1, server: 0.0.0.0:443
```